### PR TITLE
fix Adam optimizer

### DIFF
--- a/cs231n/assignment2/cs231n/optim.py
+++ b/cs231n/assignment2/cs231n/optim.py
@@ -170,6 +170,7 @@ def adam(w, dw, config=None):
     # *****START OF YOUR CODE (DO NOT DELETE/MODIFY THIS LINE)*****
 
     # t is your iteration counter going from 1 to infinity
+    config['t'] += 1 # update t
     
     config['m'] = config['beta1'] * config['m'] + (1-config['beta1']) * dw
     mt = config['m'] / (1 - config['beta1']**config['t'])


### PR DESCRIPTION
after modification:
> next_w error:  1.1395691798535431e-07
> v error:  4.208314038113071e-09
> m error:  4.214963193114416e-09

But I am quite surprised why your code works just well with this small bug, while mine is filled with numerical errors